### PR TITLE
Docs for queries, pagination, sorting

### DIFF
--- a/announcing-hydra-v3.md
+++ b/announcing-hydra-v3.md
@@ -2,14 +2,16 @@
 
 Hydra v3 is already in the works. Here are the main features planned:
 
-* Support for filtering by relations
-* Define block ranges for any mapping, i.e. specify that your mapping X should be run only from block 5 to block 7
-* Import all model files from a single library.  Instead of the cumbersome 
+- Support for filtering by relations
+- Support for adding relations to variant types
+- Ordering by multiple fields
+- Multiple filters in the same query (`AND` and `OR`)
+- Define block ranges for any mapping, i.e. specify that your mapping X should be run only from block 5 to block 7
+- Import all model files from a single library. Instead of the cumbersome
 
 ```typescript
-import { MyEntity1 }  from '../generated/graphql-server/my-entity2/my-entity2.model' 
-import { MyEntity2 }  from '../generated/graphql-server/my-entity2/my-entity2.model' 
-
+import { MyEntity1 } from '../generated/graphql-server/my-entity2/my-entity2.model'
+import { MyEntity2 } from '../generated/graphql-server/my-entity2/my-entity2.model'
 ```
 
 write
@@ -17,6 +19,3 @@ write
 ```typescript
 import { MyEntity1, MyEntity2 } from '../generated/graphql-server/model'
 ```
-
-
-

--- a/docs/paginate-query-results.md
+++ b/docs/paginate-query-results.md
@@ -1,0 +1,180 @@
+---
+description: Paginate query results
+---
+
+## The `limit` & `offset` arguments
+
+The operators limit and offset are used for pagination.
+
+`limit` specifies the number of entities to retain from the result set and `offset` determines which slice to retain from the results.
+
+Default value for `limit` is `50` and `offset` is `0`.
+
+**Limit results**
+
+Example: Fetch the first 5 channels:
+
+```graphql
+query {
+  channels(limit: 5) {
+    id
+    handle
+  }
+}
+```
+
+**Limit results from an offset**
+
+Example: Fetch 5 channels from the list of all channels, starting with the 6th one:
+
+```graphql
+query {
+  channels(limit: 5, offset: 5) {
+    id
+    handle
+  }
+}
+```
+
+## Cursor based pagination
+
+Cursors are used to traverse across entities of an entity set. They work by returning a pointer to a specific entity which can then be used to fetch the next batch of entities.
+
+For cursor based pagination for every entity in the input schema a query is generated with the `<entityName>Connection` pattern.
+
+Example: Fetch a list of videos where `isExplicit` is true and get their count. Then limit the number of videos to return.
+
+```graphql
+query {
+  videosConnection(where: { isExplicit_eq: true }) {
+    totalCount
+    edges {
+      node {
+        id
+        title
+      }
+    }
+  }
+}
+```
+
+**`first` `last` operators**
+
+The `first` operator is used to fetch specified number of entities from the beginning and `last` is vice versa.
+
+Example: Fetch first 5 videos and last 5 videos:
+
+```graphql
+query Query1 {
+  videosConnection(first: 5) {
+    edges {
+      node {
+        id
+        title
+      }
+    }
+  }
+}
+
+query Query1 {
+  videosConnection(last: 5) {
+    edges {
+      node {
+        id
+        title
+      }
+    }
+  }
+}
+```
+
+**PageInfo object**
+
+`PageInfo` returns the cursor, page information and object has following fields:
+
+```json
+pageInfo {
+  startCursor
+  endCursor
+  hasNextPage
+  hasPreviousPage
+}
+```
+
+**`before` and `after` operators**
+
+Example: Fetch a first 10 channels order by `createdAt` and then fetch the next 10 channels:
+
+```graphql
+query FirstBatchQ {
+  channelsConnection(first: 10, orderBy: createdAt_ASC) {
+    pageInfo {
+      endCursor
+      hasNextPage
+    }
+    edges {
+      node {
+        id
+        handle
+        createdAt
+      }
+    }
+  }
+}
+
+query SecondBatchQ {
+  channelsConnection(after: <endCursor>, orderBy: createdAt_ASC) {
+    pageInfo {
+      endCursor
+      hasNextPage
+    }
+    edges {
+      node {
+        id
+        handle
+        createdAt
+      }
+    }
+  }
+}
+```
+
+Example: Fetch a last 10 channels order by `createdAt` and then fetch the previous 10 channels:
+
+```graphql
+query FirstBatchQ {
+  channelsConnection(last: 10, orderBy: createdAt_ASC) {
+    pageInfo {
+      endCursor
+      hasNextPage
+    }
+    edges {
+      node {
+        id
+        handle
+        createdAt
+      }
+    }
+  }
+}
+
+query SecondBatchQ {
+  channelsConnection(before: <endCursor>, orderBy: createdAt_ASC) {
+    pageInfo {
+      endCursor
+      hasNextPage
+    }
+    edges {
+      node {
+        id
+        handle
+        createdAt
+      }
+    }
+  }
+}
+```
+
+**Important Note on orderBy**
+
+The field entities are ordered by should be fetch `node { <fieldNameThatOrderedBy> }` otherwise the returned result wouldn't be ordered correctly.

--- a/docs/queries.md
+++ b/docs/queries.md
@@ -1,0 +1,241 @@
+---
+description: GraphQL queries are used to fetch data from the server.
+---
+
+# Queries
+
+## Introduction
+
+Hydra cli tooling auto-generates queries as part of the GraphQL schema from your input schema. It generates a range of possible queries and operators that also work with relationships defined in your input schema.
+
+All entities of the input schema tracked by the cli (re-generation is required when any change happens to the input schema) can be queried over the GraphQL endpoint.
+
+## Exploring queries
+
+You can explore the entire schema and the available queries using the GraphiQL interface by running your graphql-server or looking at the graphql-server/generated/schema.graphql file.
+
+Let’s take a look at the different queries you can run using the GraphQL server. We’ll use examples based on a typical channel/video schema for reference.
+
+- Simple entity queries
+- Relation entity queries
+- Filter query results / search queries
+- Sort query results
+- Paginate query results
+
+### Simple entity queries
+
+You can fetch a single entity or multiple entities of the same type using a simple entity query.
+
+**Fetch list of entities**
+
+Example: Fetch a list of channels:
+
+```graphql
+query {
+  channels {
+    id
+    handle
+  }
+}
+```
+
+**Fetch an entity using its unique fields**
+
+Example: Fetch a channel using by unique id:
+
+```graphql
+query Query1 {
+  channelByUniqueInput(where: { id: "1" }) {
+    id
+    handle
+  }
+}
+
+query Query2 {
+  channelByUniqueInput(where: { handle: "Joy Channel" }) {
+    id
+    handle
+  }
+}
+```
+
+### Relation entity queries
+
+Please look at the cross-filters documantation.
+
+### Filter query results / search queries
+
+**The `where` argument**
+
+You can use the `where` argument in your queries to filter results based on some field’s values. You can even use multiple filters in the same where clause using the `AND` or the `OR` operators.
+
+For example, to fetch data for `Joy Channel`:
+
+```graphql
+query {
+  channels(where: { handle_eq: "Joy Channel" }) {
+    id
+    handle
+  }
+}
+```
+
+#### Comparison operators
+
+**Supported Scalar Types**
+
+Hydra supports following scalar types:
+
+- String
+- Int
+- Float
+- BigInt
+- Boolean
+- Bytes
+- DateTime
+
+**Equality Operators (`_eq`)**
+
+`_eq` is supported by all the scalar types
+
+The following are examples of using this operator on different types:
+
+1. Fetch a list of videos where `title` is "Bitcoin"
+2. Fetch a list of videos where `isExplicit` is "true"
+3. Fetch a list of videos `publishedOn` "2021-01-05"
+
+```graphql
+query Query1 {
+  videos(where: { title_eq: "Bitcoin" }) {
+    id
+    title
+  }
+}
+
+query Query2 {
+  videos(where: { isExplicit_eq: true }) {
+    id
+    title
+  }
+}
+
+query Query3 {
+  videos(where: { publishedOn_eq: "2021-01-05" }) {
+    id
+    title
+  }
+}
+```
+
+**Greater than or less than operators (`gt`, `lt`, `gte`, `lte`)**
+
+The `_gt` (greater than), `_lt` (less than), `_gte` (greater than or equal to), `_lte` (less than or equal to) operators are available on `Int, BigInt, Float, DataTime` types.
+
+The following are examples of using these operators on different types:
+
+1. Fetch a list of videos published before "2021-01-05"
+2. Fetch a list of channels before block "999"
+
+```graphql
+query Query1 {
+  videos(where: { publishedOn_gte: "2021-01-05" }) {
+    id
+    title
+  }
+}
+
+query Query2 {
+  channels(where: { block_lte: "999" }) {
+    id
+    handle
+  }
+}
+```
+
+**List based search operators (`_in`)**
+
+`_in` operator is available on all scalar types except `DataTime`.
+
+The following are examples of using this operators on different types:
+
+1. Fetch a list of videos titled with "For Children" or "For Kids"
+2. Fetch a list of channels created in block 1, 2 or 3
+
+```graphql
+query Query1 {
+  videos(where: { title_in: ["For Children", "For Kids"] }) {
+    id
+    title
+  }
+}
+
+query Query2 {
+  channels(where: { block_in: [1, 2, 3] }) {
+    id
+    handle
+  }
+}
+```
+
+**Text search or pattern matching operators (`_contains`, `_startsWith`, `_endsWith`)**
+
+The `_contains`, `_startsWith`, `_endsWith` operators are used for pattern matching on string fields.
+
+Example:
+
+```graphql
+query Query1 {
+  videos(where: { title_contains: "Bitcoin" }) {
+    id
+    title
+  }
+}
+
+query Query2 {
+  videos(where: { title_endsWith: "cryptocurrency" }) {
+    id
+    title
+  }
+}
+```
+
+#### Using multiple filters in the same query (`AND`, `OR`)
+
+You can group multiple parameters in the same where argument using the `AND` or the `OR` operators to filter results based on more than one criteria.
+
+Example `AND`:
+
+Fetch a list of videos published in a specific time-frame:
+
+```graphql
+query {
+  videos(
+    where: {
+      AND: [
+        { publishedOn_gte: "2021-01-05" }
+        { publishedOn_lte: "2020-01-05" }
+      ]
+    }
+  ) {
+    id
+    title
+    publishedOn
+  }
+}
+```
+
+Example `OR`:
+
+Fetch a list of videos isExplicit "true" or published after "2021-01-05":
+
+```graphql
+query {
+  videos(
+    where: { OR: [{ publishedOn_gte: "2021-01-05" }, { isExplicit_eq: true }] }
+  ) {
+    id
+    title
+    isExplicit
+  }
+}
+```

--- a/docs/sort-query-results.md
+++ b/docs/sort-query-results.md
@@ -1,0 +1,36 @@
+---
+description: Results from your query can be sorted by using the orderBy argument.
+---
+
+## The `orderBy` argument
+
+The sort order (ascending vs. descending) is set by specifying the asc or desc enum value for the column name in the `orderBy` input object, e.g. `title_DESC`.
+
+The `orderBy` argument takes an array of field to allow sorting by multiple columns.
+
+**Sorting entities**
+
+Example: Fetch a list of videos sorted by their titles in an ascending order:
+
+```graphql
+query {
+  videos(orderBy: [title_ASC]) {
+    id
+    title
+  }
+}
+```
+
+**Sorting entities by multiple fields**
+
+Example: Fetch a list of videos that is sorted by their titles (ascending) and then on their published date (descending):
+
+```graphql
+query {
+  videos(orderBy: [title_ASC, publishedOn_DESC]) {
+    id
+    title
+    publishedOn
+  }
+}
+```


### PR DESCRIPTION
This PR adds docs:

- Graphql queries (query single entity, a list of entity, where clause, operators, etc.)
- Paginate query results (limit & offset, cursor-based pagination)
- Sorting query results